### PR TITLE
feat: Optional message encoding.

### DIFF
--- a/src/langchain_google_firestore/chat_message_history.py
+++ b/src/langchain_google_firestore/chat_message_history.py
@@ -37,6 +37,7 @@ class FirestoreChatMessageHistory(BaseChatMessageHistory):
         session_id: str,
         collection: str = DEFAULT_COLLECTION,
         client: Optional[Client] = None,
+        encode_message: bool = True,
     ) -> None:
         """Chat Message History for Google Cloud Firestore.
 
@@ -45,7 +46,9 @@ class FirestoreChatMessageHistory(BaseChatMessageHistory):
                 chat session. This is the document_path of a document.
             collection: The single `/`-delimited path to a Firestore collection.
             client: Client for interacting with the Google Cloud Firestore API.
+            encode_message: Encode the message when storing into Firestore.
         """
+        self.encode_message = encode_message
         self.client = client_with_user_agent(USER_AGENT, client)
         self.session_id = session_id
         self.doc_ref = self.client.collection(collection).document(session_id)
@@ -57,14 +60,20 @@ class FirestoreChatMessageHistory(BaseChatMessageHistory):
         if doc.exists:
             data_messages = doc.to_dict()
             if "messages" in data_messages:
-                self.messages = decode_messages(data_messages["messages"])
+                if self.encode_message:
+                    self.messages = decode_messages(data_messages["messages"])
+                else:
+                    self.messages = data_messages["messages"]
 
     def add_message(self, message: BaseMessage) -> None:
         self.messages.append(message)
         self._upsert_messages()
 
     def _upsert_messages(self) -> None:
-        self.doc_ref.set({"messages": encode_messages(self.messages)})
+        if self.encode_message:
+            self.doc_ref.set({"messages": encode_messages(self.messages)})
+        else:
+            self.doc_ref.set({"messages": self.messages})
 
     def clear(self) -> None:
         self.messages = []

--- a/tests/test_chat_message_history.py
+++ b/tests/test_chat_message_history.py
@@ -54,7 +54,9 @@ def test_firestore_history_workflow(test_case: TestCase) -> None:
 def test_firestore_without_encoding_workflow(test_case: TestCase) -> None:
     session_id = uuid.uuid4().hex
     chat_history = FirestoreChatMessageHistory(
-        session_id=session_id, collection="HistoryWorkflow", encode_message=False,
+        session_id=session_id,
+        collection="HistoryWorkflow",
+        encode_message=False,
     )
     chat_history.add_user_message("User message")
 

--- a/tests/test_chat_message_history.py
+++ b/tests/test_chat_message_history.py
@@ -51,6 +51,26 @@ def test_firestore_history_workflow(test_case: TestCase) -> None:
     assert len(chat_history.messages) == 0
 
 
+def test_firestore_without_encoding_workflow(test_case: TestCase) -> None:
+    session_id = uuid.uuid4().hex
+    chat_history = FirestoreChatMessageHistory(
+        session_id=session_id, collection="HistoryWorkflow", encode_message=False,
+    )
+    chat_history.add_user_message("User message")
+
+    expected_messages = [
+        HumanMessage(content="User message"),
+    ]
+    chat_history._load_messages()
+
+    test_case.assertCountEqual(expected_messages, chat_history.messages)
+
+    chat_history.clear()
+    chat_history._load_messages()
+
+    assert len(chat_history.messages) == 0
+
+
 def test_firestore_load_messages(test_case: TestCase) -> None:
     NUM_MESSAGES = 25
     session_id = uuid.uuid4().hex


### PR DESCRIPTION
Add support for optional message encoding.

When storing the chat messages into Firestore by default we encode the string. With this PR it will be possible to make that optional.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/langchain-google-firestore-python/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes https://github.com/googleapis/langchain-google-firestore-python/issues/57 
