### PR TITLE
chore: Improve vector store documentation

### DIFF
--- a/docs/vectorstores.ipynb
+++ b/docs/vectorstores.ipynb
@@ -190,7 +190,7 @@
     "# Create a vector store\n",
     "vector_store = FirestoreVectorStore(\n",
     "    collection=\"fruits\",\n",
-    "    embedding=embedding,\n",
+    "    embedding_service=embedding,\n",
     ")\n",
     "\n",
     "# Add the fruits to the vector store\n",

--- a/docs/vectorstores.ipynb
+++ b/docs/vectorstores.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Google Firestore (Native Mode)\n",
     "\n",
-    "> [Firestore](https://cloud.google.com/firestore) is a serverless document-oriented database that scales to meet any demand. Extend your database application to build AI-powered experiences leveraging Firestore's Langchain integrations.\n",
+    "> [Firestore](https://cloud.google.com/firestore) is a serverless document-oriented database that scales to meet any demand. Extend your database application to build AI-powered experiences leveraging Firestore's LangChain integrations.\n",
     "\n",
     "This notebook goes over how to use [Firestore](https://cloud.google.com/firestore) to to store vectors and query them using the `FirestoreVectorStore` class.\n",
     "\n",
@@ -189,7 +189,7 @@
     "\n",
     "# Create a vector store\n",
     "vector_store = FirestoreVectorStore(\n",
-    "    collection=\"fruits\",\n",
+    "    collection=COLLECTION_NAME,\n",
     "    embedding_service=embedding,\n",
     ")\n",
     "\n",
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "vector_store = FirestoreVectorStore.from_texts(\n",
-    "    collection=\"fruits\",\n",
+    "    collection=COLLECTION_NAME,\n",
     "    texts=fruits_texts,\n",
     "    embedding=embedding,\n",
     ")"
@@ -231,7 +231,7 @@
     "fruits_docs = [Document(page_content=fruit) for fruit in fruits_texts]\n",
     "\n",
     "vector_store = FirestoreVectorStore.from_documents(\n",
-    "    collection=\"fruits\",\n",
+    "    collection=COLLECTION_NAME,\n",
     "    documents=fruits_docs,\n",
     "    embedding=embedding,\n",
     ")"
@@ -299,7 +299,9 @@
    "source": [
     "## Similarity Search\n",
     "\n",
-    "You can use the `FirestoreVectorStore` to perform similarity searches on the vectors you have stored. This is useful for finding similar documents or text."
+    "You can use the `FirestoreVectorStore` to perform similarity searches on the vectors you have stored. This is useful for finding similar documents or text.\n",
+    "\n",
+    "**Note:** Similarity search requires a [composite vector index](https://cloud.google.com/firestore/docs/vector-search#create_and_manage_vector_indexes). Use the error message from the below commands to identify which indexes should be created using `gcloud` ."
    ]
   },
   {
@@ -368,8 +370,8 @@
     "\n",
     "# Create a vector store\n",
     "vector_store = FirestoreVectorStore(\n",
-    "    collection=\"fruits\",\n",
-    "    embedding=embedding,\n",
+    "    collection=COLLECTION_NAME,\n",
+    "    embedding_service=embedding,\n",
     "    client=client,\n",
     ")"
    ]

--- a/src/langchain_google_firestore/vectorstores.py
+++ b/src/langchain_google_firestore/vectorstores.py
@@ -57,7 +57,7 @@ class FirestoreVectorStore(VectorStore):
         """Constructor for FirestoreVectorStore.
 
         Args:
-            source (CollectionReference | str): The source collection or document
+            collection (CollectionReference | str): The source collection or document
             reference to store the data.
             embedding_service (Embeddings): The embeddings to use for the vector store.
             client (Optional[Client]): The Firestore client to use. If not provided,

--- a/src/langchain_google_firestore/vectorstores.py
+++ b/src/langchain_google_firestore/vectorstores.py
@@ -59,7 +59,7 @@ class FirestoreVectorStore(VectorStore):
         Args:
             source (CollectionReference | str): The source collection or document
             reference to store the data.
-            embedding (Embeddings): The embeddings to use for the vector store.
+            embedding_service (Embeddings): The embeddings to use for the vector store.
             client (Optional[Client]): The Firestore client to use. If not provided,
             a new client will be created.
             content_field (str): The field name to store the content data.


### PR DESCRIPTION
This makes the following changes:
* Adds note about composite vector indexes being required
* Switches from `embedding` to `embedding_service` in `FirestoreVectorStore` tutorial snippets.
* Uses `COLLECTION_NAME` in code snippets.
* Fixes arg names in `FirestoreVectorStore` docstring.