### PR TITLE
chore(deps): Remove py39 integration test requirements.

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -27,7 +27,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - "cla/google"
       - "lint"
-      - "integration-test-pr-py39 (langchain-firestore-testing)"
       - "integration-test-pr-py310 (langchain-firestore-testing)"
       - "integration-test-pr-py311 (langchain-firestore-testing)"
       - "integration-test-pr-py312 (langchain-firestore-testing)"


### PR DESCRIPTION
Remove py39 integration test requirements in preparation for py39 removal.
