### PR TITLE
chore: replace old partner teams with new ones (Wave 2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*   @googleapis/senseai-eco @googleapis/langchain-firestore
+*   @googleapis/senseai-eco-team @googleapis/langchain-firestore-team

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,4 @@
 assign_issues:
-  - googleapis/langchain-firestore
+  - googleapis/langchain-firestore-team
 assign_prs:
-  - googleapis/langchain-firestore
+  - googleapis/langchain-firestore-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,5 @@
     "repo": "googleapis/langchain-google-firestore-python",
     "distribution_name": "langchain-google-firestore",
     "requires_billing": true,
-    "codeowner_team": "@googleapis/senseai-eco"
+    "codeowner_team": "@googleapis/senseai-eco-team"
 }


### PR DESCRIPTION
Replacing old partner teams with new ones as part of Wave 2 migration. b/478003109