### PR TITLE
chore(deps)!: Update to langchain-core 1.0, drops python3.9 support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## [0.6.0](https://github.com/googleapis/langchain-google-firestore-python/compare/v0.5.0...v0.6.0) (2025-01-02)
+
+* Remove support for Python 3.9 ([#151](https://github.com/googleapis/langchain-google-firestore-python/issues/151))
+
 ## [0.5.0](https://github.com/googleapis/langchain-google-firestore-python/compare/v0.4.0...v0.5.0) (2024-10-29)
 
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -38,11 +38,11 @@ These tests are registered as required tests in `.github/sync-repo-settings.yaml
 
 #### Trigger Setup
 
-Cloud Build triggers (for Python versions 3.8 to 3.11) were created with the following specs:
+Cloud Build triggers (for Python versions 3.10 to 3.11) were created with the following specs:
 
 ```YAML
-name: integration-test-pr-py39
-description: Run integration tests on PR for Python 3.9
+name: integration-test-pr-py310
+description: Run integration tests on PR for Python 3.10
 filename: integration.cloudbuild.yaml
 github:
   name: langchain-google-firestore-python
@@ -56,7 +56,7 @@ ignoredFiles:
   - .github/**
   - "*.md"
 substitutions:
-  _VERSION: "3.9"
+  _VERSION: "3.10"
 ```
 
 Use `gcloud builds triggers import --source=trigger.yaml` to create triggers via the command line

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
     args: ["-m", "pytest", "--cov=langchain_google_firestore", "--cov-config=.coveragerc", "tests/"]
 
 substitutions:
-  _VERSION: "3.9"
+  _VERSION: "3.10"
 
 options:
   dynamicSubstitutions: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "LangChain integrations for Google Cloud Firestore"
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -51,7 +50,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    "langchain-core>=0.1.1, <1.0.0",
-    "langchain-community>=0.0.18, <1.0.0",
+    "langchain-core>=1.2.22, <2.0.0",
+    "langchain-community>=0.4.2, <1.0.0",
     "google-cloud-firestore>=2.16.0, <3.0.0",
     "google-cloud-storage>=3.2.0, <3.3.0",
     "more_itertools>=10.2.0, <11.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-langchain-core==0.3.81
-langchain-community==0.3.27
+langchain-core==1.2.31
+langchain-community==0.4.2
 google-cloud-firestore==2.21.0
 google-cloud-storage==3.2.0
 more-itertools==10.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ langchain-community==0.4.2
 google-cloud-firestore==2.21.0
 google-cloud-storage==3.2.0
 more-itertools==10.7.0
-requests==2.32.4
+requests==2.32.5

--- a/src/langchain_google_firestore/version.py
+++ b/src/langchain_google_firestore/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
Fixes https://github.com/googleapis/langchain-google-firestore-python/issues/151.